### PR TITLE
add exact match

### DIFF
--- a/.github/pr_label_config.yml
+++ b/.github/pr_label_config.yml
@@ -1,5 +1,3 @@
-bug:
-  - bug
 feat:
   - feat
 hotfix:

--- a/dist/index.js
+++ b/dist/index.js
@@ -19793,24 +19793,27 @@ actions_toolkit_1.Toolkit.run(function (tools) { return __awaiter(void 0, void 0
             arr.splice(index, 1);
         }
     }
-    /* Given string strBase does it start with strMatch
+    /* Given string strBase does it (default) start with || matches strMatch
     *  returns: True|False
     */
-    function Str_Match(strBase, strMatch) {
-        if (strBase.toLowerCase().startsWith(strMatch.toLowerCase())) {
+    function Str_Match(strBase, strMatch, exactMatch) {
+        if (exactMatch === void 0) { exactMatch = false; }
+        if ((!exactMatch && strBase.toLowerCase().startsWith(strMatch.toLowerCase())) ||
+            (exactMatch && strBase.toLowerCase() === strMatch.toLowerCase())) {
             return true;
         }
         else {
             return false;
         }
     }
-    /* Given array arrBase for each item, does it start with strMatch
+    /* Given array arrBase for each item, does it starts with || matches (default) strMatch
     *  returns: True|False
     */
-    function Arr_Match(arrBase, strMatch) {
+    function Arr_Match(arrBase, strMatch, exactMatch) {
+        if (exactMatch === void 0) { exactMatch = true; }
         for (var _i = 0, arrBase_1 = arrBase; _i < arrBase_1.length; _i++) {
             var item = arrBase_1[_i];
-            if (Str_Match(item, strMatch)) {
+            if (Str_Match(item, strMatch, exactMatch)) {
                 return true;
             }
         }

--- a/src/action.js
+++ b/src/action.js
@@ -324,24 +324,27 @@ actions_toolkit_1.Toolkit.run(function (tools) { return __awaiter(void 0, void 0
             arr.splice(index, 1);
         }
     }
-    /* Given string strBase does it start with strMatch
+    /* Given string strBase does it (default) start with || matches strMatch
     *  returns: True|False
     */
-    function Str_Match(strBase, strMatch) {
-        if (strBase.toLowerCase().startsWith(strMatch.toLowerCase())) {
+    function Str_Match(strBase, strMatch, exactMatch) {
+        if (exactMatch === void 0) { exactMatch = false; }
+        if ((!exactMatch && strBase.toLowerCase().startsWith(strMatch.toLowerCase())) ||
+            (exactMatch && strBase.toLowerCase() === strMatch.toLowerCase())) {
             return true;
         }
         else {
             return false;
         }
     }
-    /* Given array arrBase for each item, does it start with strMatch
+    /* Given array arrBase for each item, does it starts with || matches (default) strMatch
     *  returns: True|False
     */
-    function Arr_Match(arrBase, strMatch) {
+    function Arr_Match(arrBase, strMatch, exactMatch) {
+        if (exactMatch === void 0) { exactMatch = true; }
         for (var _i = 0, arrBase_1 = arrBase; _i < arrBase_1.length; _i++) {
             var item = arrBase_1[_i];
-            if (Str_Match(item, strMatch)) {
+            if (Str_Match(item, strMatch, exactMatch)) {
                 return true;
             }
         }

--- a/src/action.ts
+++ b/src/action.ts
@@ -319,24 +319,25 @@ Toolkit.run( async tools => {
 		}
 	}
 
-	/* Given string strBase does it start with strMatch
+	/* Given string strBase does it (default) start with || matches strMatch
 	*  returns: True|False
 	*/
-	function Str_Match(strBase :string, strMatch :string) {
+	function Str_Match(strBase :string, strMatch :string, exactMatch : boolean = false) {
 
-		if (strBase.toLowerCase().startsWith(strMatch.toLowerCase())) {
+		if ((!exactMatch && strBase.toLowerCase().startsWith(strMatch.toLowerCase())) || 
+			(exactMatch && strBase.toLowerCase() === strMatch.toLowerCase()) ) {
 			return true;
 		}
 		else { return false; }
 	}
 
-	/* Given array arrBase for each item, does it start with strMatch
+	/* Given array arrBase for each item, does it starts with || matches (default) strMatch
 	*  returns: True|False
 	*/
-	function Arr_Match(arrBase :string[], strMatch :string) {
+	function Arr_Match(arrBase :string[], strMatch :string, exactMatch :boolean = true) {
 
 		for (let item of arrBase) {
-			if (Str_Match(item,strMatch)) {
+			if (Str_Match(item,strMatch, exactMatch)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
PR labels are matched with defined labels with the `starts with` matching. This can lead to incorrect behaviour when multiple labels on PR being with same word e.g. `bug` and `bugfix`.
Solution: Add exact match for labels

Test
![image](https://user-images.githubusercontent.com/85170301/129736981-97e8898f-1bc4-453a-908c-a38b92d777b5.png)

